### PR TITLE
Add missing } in functionFindSource.sh

### DIFF
--- a/functions/functionFindSource.sh
+++ b/functions/functionFindSource.sh
@@ -20,3 +20,4 @@ read -p "Enter file name: (default skip)" FILE
      echo $varCheckForLocalSource
      functionLocalVsDownload
   fi
+}


### PR DESCRIPTION
Without this change, the whole script fails for me with:
    ./installer.sh: line 14: functionFindSource: command not found